### PR TITLE
Migrate envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ hasPassword:        not('socialOnly')
 
 #### Network Requests
 
-Interacting with the backend service should be handled by other, higher-level addons, such as the [nypr-account-settings](https://github.com/nypublicradio/nypr-account-settings), but for reference, the requests related to the user model will be listed here. The expected [environment variables](#config-values) are detailed further below. Environment variables will be notated in angle brackets.
+Interacting with the backend service should be handled by other, higher-level addons, such as the [nypr-account-settings](https://github.com/nypublicradio/nypr-account-settings), but for reference, the requests related to the user model will be listed here. The expected [config values](#config-values) are detailed further below. Config values will be notated in angle brackets.
 
 Auth headers are added to all outgoing user-related requests.
 * `X-Provider`: string value hint for back end service if a third-party service (e.g. Facebook) provided the auth token
@@ -37,7 +37,7 @@ See the [auth microservice REST docs](http://docs.nyprauth.apiary.io) for more i
 
 #### Get Current User
 ```
-GET <AUTH_SERVICE>/v1/session
+GET <authAPI>/v1/session
 ```
 
 The call to the store to retrieve the current user is actually a `query`, instead of a `findRecord`, which is what the `ember-data` semantics would dictate. The reason for this is described in [this guide from `ember-simple-auth` on managing the current user](https://github.com/simplabs/ember-simple-auth/blob/master/guides/managing-current-user.md). This addon follows the pattern outlined there very closely.
@@ -45,24 +45,24 @@ The call to the store to retrieve the current user is actually a `query`, instea
 #### Create a User
 Post body is an object of field names and values for the new user.
 ```
-POST <AUTH_SERVICE>/v1/user
+POST <authAPI>/v1/user
 ```
 
 #### Update a User 
 ```
-PATCH <AUTH_SERVICE>/v1/user
+PATCH <authAPI>/v1/user
 ```
 Outgoing `PATCH` requests only include values for the fields that are changing, as specified by the JSON merge patch strategy outlined here: https://tools.ietf.org/html/rfc7396.
 
 #### Delete a User
 ```
-DELETE <AUTH_SERVICE>/v1/user
+DELETE <authAPI>/v1/user
 ```
 
 ### Authenticators and Authorizers
 
 #### `nypr` authenticator
-A basic extension of ESA's `OAuth2PasswordGrantAuthenticator`, specifying the `serverTokenEndpoint` as `<AUTH_SERVICE>/v1/session`.
+A basic extension of ESA's `OAuth2PasswordGrantAuthenticator`, specifying the `serverTokenEndpoint` as `<authAPI>/v1/session`.
 
 #### `torii` authenticator
 Overrides the `authenticate` and `getSession` methods of the basic torii authenticator to communicate with our auth service back end when a user to credentialed via a third-party API.
@@ -134,13 +134,13 @@ This method can be used to perform a basic check against the auth service with a
 ## Config Values
 This addon requires a small set of config values in order for it to connect to the correct back end services.
 
-##### `wnycAuthAPI`
+##### `authAPI`
 The host of the `auth` microservice backend. Used for most auth-related requests.
 
-##### `wnycAdminRoot`
+##### `adminRoot`
 Publisher's admin backend host. Used to see if the current session is authenticated as a staff user.
 
-##### `wnycEtagAPI`
+##### `etagAPI`
 The full host and pathname to the `browserID` endpoint. It's currently named `EtagAPI` for legacy reasons, but that is subject to change.
 
 

--- a/addon/adapters/user.js
+++ b/addon/adapters/user.js
@@ -1,11 +1,11 @@
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import DS from 'ember-data';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 const { keys } = Object;
 
 export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
   authorizer: 'authorizer:nypr',
-  host: ENV.wnycAuthAPI,
+  host: config.authAPI,
   buildURL(modelName, id, snapshot, requestType, query) {
     if (/createRecord|updateRecord|deleteRecord/.test(requestType)) {
       return `${this.host}/v1/user`;

--- a/addon/authenticators/nypr.js
+++ b/addon/authenticators/nypr.js
@@ -2,5 +2,5 @@ import config from 'ember-get-config';
 import OAuth2PasswordGrantAuthenticator from 'ember-simple-auth/authenticators/oauth2-password-grant';
 
 export default OAuth2PasswordGrantAuthenticator.extend({
-  serverTokenEndpoint: `${config.wnycAuthAPI}/v1/session`
+  serverTokenEndpoint: `${config.authAPI}/v1/session`
 });

--- a/addon/authenticators/torii.js
+++ b/addon/authenticators/torii.js
@@ -32,7 +32,7 @@ export default Torii.extend({
   },
 
   getSession(provider, accessToken) {
-    return fetch(`${config.wnycAuthAPI}/v1/session`, {
+    return fetch(`${config.authAPI}/v1/session`, {
       method: 'GET',
       headers: {
         'Authorization': `Bearer ${accessToken}`,

--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -36,7 +36,7 @@ export default SessionService.extend({
   },
 
   staffAuth() {
-    fetch(`${config.wnycAdminRoot}/api/v1/is_logged_in/?bust_cache=${Math.random()}`, {
+    fetch(`${config.adminRoot}/api/v1/is_logged_in/?bust_cache=${Math.random()}`, {
       credentials: 'include'
     })
     .then(checkStatus).then(r => r.json())
@@ -55,13 +55,13 @@ export default SessionService.extend({
 });
 
 function reportBrowserId(knownId) {
-  fetch(config.wnycEtagAPI, {
+  fetch(config.etagAPI, {
     headers: { 'X-WNYC-BrowserId': knownId }
   });
 }
 
 function getBrowserId() {
-  return fetch(config.wnycEtagAPI)
+  return fetch(config.etagAPI)
     .then(checkStatus)
     .then(response => response.json());
 }


### PR DESCRIPTION
Updates to better organize envvars and remove the `wnyc` prefix.

Envvars renamed in this addon:
* `wnycAuthAPI` -> `authAPI`
* `wnycAdminRoot` -> `adminRoot`
* `wnycEtagAPI` -> `etagAPI`